### PR TITLE
feat: 카테고리별 문의 가져오기 기능 구현

### DIFF
--- a/src/modules/QnAPagination/QnAPagination.jsx
+++ b/src/modules/QnAPagination/QnAPagination.jsx
@@ -1,495 +1,69 @@
 import { useEffect, useState } from "react";
 import { Link } from "../../components/Link";
-import leftArrowButton from "../../icons/chevron-left-large.svg"
-import rightArrowButton from "../../icons/chevron-right-large.svg"
-import { inquiry, courseInquiry } from "../../store";
-
-const QnAList = [
-  {
-    id: 1,
-    title: "환불 가능한가요?",
-    category: "QnA",
-    writer: "너구리",
-    publishDate: "2024-03-15",
-    views: 512,
-  },
-  {
-    id: 2,
-    title: "이름을 잘못 적었어요.",
-    category: "QnA",
-    writer: "짱짱맨",
-    publishDate: "2024-02-28",
-    views: 291,
-  },
-  {
-    id: 3,
-    title: "수료증은 어디서 확인할 수 있죠?",
-    category: "QnA",
-    writer: "데이빗",
-    publishDate: "2024-01-20",
-    views: 465,
-  },
-  {
-    id: 4,
-    title: "이수증서는 어디에서 사용이 가능한가요?",
-    category: "QnA",
-    writer: "주노",
-    publishDate: "2024-03-01",
-    views: 300,
-  },
-  {
-    id: 5,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "QnA",
-    writer: "튜니",
-    publishDate: "2024-01-10",
-    views: 620,
-  },
-  {
-    id: 6,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "QnA",
-    writer: "에드워드",
-    publishDate: "2024-03-05",
-    views: 350,
-  },
-  {
-    id: 7,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "QnA",
-    writer: "루시오",
-    publishDate: "2024-02-14",
-    views: 410,
-  },
-  {
-    id: 8,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "QnA",
-    writer: "Sophie Lee",
-    publishDate: "2024-02-20",
-    views: 255,
-  },
-  {
-    id: 9,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "QnA",
-    writer: "Lucas Kim",
-    publishDate: "2024-03-03",
-    views: 530,
-  },
-  {
-    id: 10,
-    title: "이수증서는 어디에서 사용이 가능한가요?",
-    category: "QnA",
-    writer: "Olivia Jeong",
-    publishDate: "2024-03-18",
-    views: 480,
-  },
-  {
-    id: 11,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "QnA",
-    writer: "Brian Choi",
-    publishDate: "2024-02-22",
-    views: 390,
-  },
-  {
-    id: 12,
-    title: "How to Stay Safe Online",
-    category: "QnA",
-    writer: "Grace Park",
-    publishDate: "2024-03-10",
-    views: 650,
-  },
-  {
-    id: 13,
-    title: "Global Economic Outlook for 2024",
-    category: "QnA",
-    writer: "Ethan Kang",
-    publishDate: "2024-01-25",
-    views: 280,
-  },
-  {
-    id: 14,
-    title: "Innovations in Artificial Intelligence",
-    category: "QnA",
-    writer: "Lily Kim",
-    publishDate: "2024-02-15",
-    views: 500,
-  },
-  {
-    id: 15,
-    title: "Learning Foreign Languages",
-    category: "QnA",
-    writer: "Noah Lee",
-    publishDate: "2024-02-05",
-    views: 320,
-  },
-  {
-    id: 16,
-    title: "Nutritional Myths Debunked",
-    category: "QnA",
-    writer: "Emma Choi",
-    publishDate: "2024-03-07",
-    views: 290,
-  },
-  {
-    id: 17,
-    title: "The Evolution of Cinema",
-    category: "QnA",
-    writer: "Jack Kim",
-    publishDate: "2024-02-12",
-    views: 430,
-  },
-  {
-    id: 18,
-    title: "Ultimate Guide to Backpacking in Europe",
-    category: "QnA",
-    writer: "Chloe Lee",
-    publishDate: "2024-03-21",
-    views: 370,
-  },
-  {
-    id: 19,
-    title: "Mindfulness and Mental Health",
-    category: "QnA",
-    writer: "Daniel Yoo",
-    publishDate: "2024-01-30",
-    views: 260,
-  },
-  {
-    id: 20,
-    title: "Revolutionizing Healthcare with Technology",
-    category: "QnA",
-    writer: "Sophia Park",
-    publishDate: "2024-02-01",
-    views: 540,
-  },
-];
-
-const SentencingList = [
-  {
-    id: 1,
-    title: "양형교육이란 무엇인가요?",
-    category: "양형교육",
-    writer: "김수한무",
-    publishDate: "2024-03-15",
-    views: 512,
-  },
-  {
-    id: 2,
-    title: "이수증서는 어디서 사용할 수 있나요?",
-    category: "양형교육",
-    writer: "거북이와두리미",
-    publishDate: "2024-02-28",
-    views: 291,
-  },
-  {
-    id: 3,
-    title: "완강했는데, 수료증은 어디서 확인할 수 있죠?",
-    category: "양형교육",
-    writer: "삼천갑자",
-    publishDate: "2024-01-20",
-    views: 465,
-  },
-  {
-    id: 4,
-    title: "범죄사실은 없지만 양형교육을 들어도 상관없나요?",
-    category: "양형교육",
-    writer: "동박삭",
-    publishDate: "2024-03-01",
-    views: 300,
-  },
-  {
-    id: 5,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "양형교육",
-    writer: "치치카포",
-    publishDate: "2024-01-10",
-    views: 620,
-  },
-  {
-    id: 6,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "양형교육",
-    writer: "사리사리센타",
-    publishDate: "2024-03-05",
-    views: 350,
-  },
-  {
-    id: 7,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "양형교육",
-    writer: "워리워리",
-    publishDate: "2024-02-14",
-    views: 410,
-  },
-  {
-    id: 8,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "양형교육",
-    writer: "Sophie Lee",
-    publishDate: "2024-02-20",
-    views: 255,
-  },
-  {
-    id: 9,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "양형교육",
-    writer: "Lucas Kim",
-    publishDate: "2024-03-03",
-    views: 530,
-  },
-  {
-    id: 10,
-    title: "이수증서는 어디에서 사용이 가능한가요?",
-    category: "양형교육",
-    writer: "Olivia Jeong",
-    publishDate: "2024-03-18",
-    views: 480,
-  },
-  {
-    id: 11,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "양형교육",
-    writer: "Brian Choi",
-    publishDate: "2024-02-22",
-    views: 390,
-  },
-  {
-    id: 12,
-    title: "How to Stay Safe Online",
-    category: "양형교육",
-    writer: "Grace Park",
-    publishDate: "2024-03-10",
-    views: 650,
-  },
-  {
-    id: 13,
-    title: "Global Economic Outlook for 2024",
-    category: "양형교육",
-    writer: "Ethan Kang",
-    publishDate: "2024-01-25",
-    views: 280,
-  },
-  {
-    id: 14,
-    title: "Innovations in Artificial Intelligence",
-    category: "양형교육",
-    writer: "Lily Kim",
-    publishDate: "2024-02-15",
-    views: 500,
-  },
-  {
-    id: 15,
-    title: "Learning Foreign Languages",
-    category: "양형교육",
-    writer: "Noah Lee",
-    publishDate: "2024-02-05",
-    views: 320,
-  },
-  {
-    id: 16,
-    title: "Nutritional Myths Debunked",
-    category: "양형교육",
-    writer: "Emma Choi",
-    publishDate: "2024-03-07",
-    views: 290,
-  },
-  {
-    id: 17,
-    title: "The Evolution of Cinema",
-    category: "양형교육",
-    writer: "Jack Kim",
-    publishDate: "2024-02-12",
-    views: 430,
-  },
-  {
-    id: 18,
-    title: "Ultimate Guide to Backpacking in Europe",
-    category: "양형교육",
-    writer: "Chloe Lee",
-    publishDate: "2024-03-21",
-    views: 370,
-  },
-  {
-    id: 19,
-    title: "Mindfulness and Mental Health",
-    category: "양형교육",
-    writer: "Daniel Yoo",
-    publishDate: "2024-01-30",
-    views: 260,
-  },
-];
-
-const DigitalUndertakerList = [
-  {
-    id: 1,
-    title: "디지털장의사란 무엇인가요?",
-    category: "디지털장의사",
-    writer: "가가가",
-    publishDate: "2024-03-15",
-    views: 512,
-  },
-  {
-    id: 2,
-    title: "이수증서는 어디서 사용할 수 있나요?",
-    category: "디지털장의사",
-    writer: "나나나",
-    publishDate: "2024-02-28",
-    views: 291,
-  },
-  {
-    id: 3,
-    title: "완강했는데, 수료증은 어디서 확인할 수 있죠?",
-    category: "디지털장의사",
-    writer: "다다다",
-    publishDate: "2024-01-20",
-    views: 465,
-  },
-  {
-    id: 4,
-    title: "범죄사실은 없지만 디지털 장의사 교육을 들어도 상관없나요? 궁금해요",
-    category: "디지털장의사",
-    writer: "라라라",
-    publishDate: "2024-03-01",
-    views: 300,
-  },
-  {
-    id: 5,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "디지털장의사",
-    writer: "마마마",
-    publishDate: "2024-01-10",
-    views: 620,
-  },
-  {
-    id: 6,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "디지털장의사",
-    writer: "바바바",
-    publishDate: "2024-03-05",
-    views: 350,
-  },
-  {
-    id: 7,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "디지털장의사",
-    writer: "사사사",
-    publishDate: "2024-02-14",
-    views: 410,
-  },
-  {
-    id: 8,
-    title: "OOOO 교육 영상은 없나요?",
-    category: "디지털장의사",
-    writer: "Sophie Lee",
-    publishDate: "2024-02-20",
-    views: 255,
-  },
-  {
-    id: 9,
-    title: "설문조사를 해야지만 이수증서를 받을 수 있나요?",
-    category: "디지털장의사",
-    writer: "Lucas Kim",
-    publishDate: "2024-03-03",
-    views: 530,
-  },
-  {
-    id: 10,
-    title: "이수증서는 어디에서 사용이 가능한가요?",
-    category: "디지털장의사",
-    writer: "Olivia Jeong",
-    publishDate: "2024-03-18",
-    views: 480,
-  },
-  {
-    id: 11,
-    title: "회사메일로 가입할 수 없나요?",
-    category: "디지털장의사",
-    writer: "Brian Choi",
-    publishDate: "2024-02-22",
-    views: 390,
-  },
-  {
-    id: 12,
-    title: "How to Stay Safe Online",
-    category: "디지털장의사",
-    writer: "Grace Park",
-    publishDate: "2024-03-10",
-    views: 650,
-  },
-  {
-    id: 13,
-    title: "Global Economic Outlook for 2024",
-    category: "디지털장의사",
-    writer: "Ethan Kang",
-    publishDate: "2024-01-25",
-    views: 280,
-  },
-  {
-    id: 14,
-    title: "Innovations in Artificial Intelligence",
-    category: "디지털장의사",
-    writer: "Lily Kim",
-    publishDate: "2024-02-15",
-    views: 500,
-  },
-  {
-    id: 15,
-    title: "Learning Foreign Languages",
-    category: "디지털장의사",
-    writer: "Noah Lee",
-    publishDate: "2024-02-05",
-    views: 320,
-  },
-  {
-    id: 16,
-    title: "Nutritional Myths Debunked",
-    category: "디지털장의사",
-    writer: "Emma Choi",
-    publishDate: "2024-03-07",
-    views: 290,
-  },
-  {
-    id: 17,
-    title: "The Evolution of Cinema",
-    category: "디지털장의사",
-    writer: "Jack Kim",
-    publishDate: "2024-02-12",
-    views: 430,
-  },
-];
+import leftArrowButton from "../../icons/chevron-left-large.svg";
+import rightArrowButton from "../../icons/chevron-right-large.svg";
+import { inquiry, courseInquiry, service } from "../../store";
 
 export const QnAPagination = () => {
-  const [activeTab, setActiveTab] = useState("QnA");
+  const [activeTab, setActiveTab] = useState("메인게시판");
+  const [categories, setCategories] = useState([]);
+
+  const { getInquiries, inquiries, clearInquiries } = inquiry((state) => ({
+    getInquiries: state.getInquiries,
+    inquiries: state.inquiries,
+    clearInquiries: state.clearInquiries,
+  }));
+
+  const { getCourseInquiriesByCategory, courseInquiries } = courseInquiry((state) => ({
+    getCourseInquiriesByCategory: state.getCourseInquiriesByCategory,
+    courseInquiries: state.courseInquiries,
+  }));
+
+  const { getCategories } = service((state) => ({
+    getCategories: state.getCategories,
+  }));
 
   const handleTabClick = (tab) => {
     setActiveTab(tab);
   };
 
-  const {getInquiries, inquiries, clearInquiries} = inquiry((state=> ({getInquiries: state.getInquiries, inquiries: state.inquiries, clearInquiries: state.clearInquiries})))
+  useEffect(() => {
+    if (activeTab === "메인게시판") {
+      clearInquiries();
+      getInquiries();
+    } else {
+      getCourseInquiriesByCategory(activeTab);
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const fetchCategories = async () => {
+    try {
+      const categories = await getCategories();
+      console.log(categories);
+      setCategories(categories);
+    } catch (error) {
+      console.error("Failed to fetch categories:", error);
+    }
+  };
 
   const [currentPage, setCurrentPage] = useState(1);
-  const postsPerPage = 7; // 한 페이지당 보여줄 데이터 수를 7로 변경
-  const totalPosts = inquiries.length;
+  const postsPerPage = 7;
+  const totalPosts = activeTab === "메인게시판" ? inquiries.length : courseInquiries.length;
 
   const handlePageChange = (page) => {
     setCurrentPage(page);
   };
 
-  useEffect(()=>{
-    clearInquiries();
-    getInquiries()
-  },[])
-
-  const renderPageButtons = () => {
+  const renderPageButtons = (totalPosts) => {
     const pageButtons = [];
     const totalPages = Math.ceil(totalPosts / postsPerPage);
     let startPage = Math.max(currentPage - 2, 1);
     let endPage = Math.min(startPage + 4, totalPages);
 
-    // 현재 페이지가 첫 번째 페이지에 가까워서 페이지 버튼이 충분하지 않은 경우
     if (endPage - startPage < 4) {
       startPage = Math.max(endPage - 4, 1);
     }
@@ -515,97 +89,10 @@ export const QnAPagination = () => {
 
   const indexOfLastPost = currentPage * postsPerPage;
   const indexOfFirstPost = indexOfLastPost - postsPerPage;
-  const currentPosts = inquiries.slice(indexOfFirstPost, indexOfLastPost);
-
-  const [currentPage2, setCurrentPage2] = useState(1);
-  const postsPerPage2 = 7; // 한 페이지당 보여줄 데이터 수를 7로 변경
-  const totalPosts2 = SentencingList.length;
-
-  const handlePageChange2 = (page) => {
-    setCurrentPage2(page);
-  };
-
-  const renderPageButtons2 = () => {
-    const pageButtons2 = [];
-    const totalPages2 = Math.ceil(totalPosts2 / postsPerPage);
-    let startPage2 = Math.max(currentPage2 - 2, 1);
-    let endPage2 = Math.min(startPage2 + 4, totalPages2);
-
-    // 현재 페이지가 첫 번째 페이지에 가까워서 페이지 버튼이 충분하지 않은 경우
-    if (endPage2 - startPage2 < 4) {
-      startPage2 = Math.max(endPage2 - 4, 1);
-    }
-
-    for (let i = startPage2; i <= endPage2; i++) {
-      pageButtons2.push(
-        <button
-          key={i}
-          className={
-            currentPage2 === i
-              ? "users-pagination-page-button active"
-              : "users-pagination-page-button"
-          }
-          onClick={() => handlePageChange2(i)}
-        >
-          {i}
-        </button>
-      );
-    }
-
-    return pageButtons2;
-  };
-
-  const indexOfLastPost2 = currentPage2 * postsPerPage2;
-  const indexOfFirstPost2 = indexOfLastPost2 - postsPerPage2;
-  const currentPosts2 = SentencingList.slice(
-    indexOfFirstPost2,
-    indexOfLastPost2
-  );
-
-  const [currentPage3, setCurrentPage3] = useState(1);
-  const postsPerPage3 = 7; // 한 페이지당 보여줄 데이터 수를 7로 변경
-  const totalPosts3 = DigitalUndertakerList.length;
-
-  const handlePageChange3 = (page) => {
-    setCurrentPage3(page);
-  };
-
-  const renderPageButtons3 = () => {
-    const pageButtons3 = [];
-    const totalPages3 = Math.ceil(totalPosts3 / postsPerPage);
-    let startPage3 = Math.max(currentPage3 - 2, 1);
-    let endPage3 = Math.min(startPage3 + 4, totalPages3);
-
-    // 현재 페이지가 첫 번째 페이지에 가까워서 페이지 버튼이 충분하지 않은 경우
-    if (endPage3 - startPage3 < 4) {
-      startPage3 = Math.max(endPage3 - 4, 1);
-    }
-
-    for (let i = startPage3; i <= endPage3; i++) {
-      pageButtons3.push(
-        <button
-          key={i}
-          className={
-            currentPage3 === i
-              ? "users-pagination-page-button active"
-              : "users-pagination-page-button"
-          }
-          onClick={() => handlePageChange3(i)}
-        >
-          {i}
-        </button>
-      );
-    }
-
-    return pageButtons3;
-  };
-
-  const indexOfLastPost3 = currentPage3 * postsPerPage3;
-  const indexOfFirstPost3 = indexOfLastPost3 - postsPerPage3;
-  const currentPosts3 = DigitalUndertakerList.slice(
-    indexOfFirstPost3,
-    indexOfLastPost3
-  );
+  const currentPosts =
+    activeTab === "메인게시판"
+      ? inquiries.slice(indexOfFirstPost, indexOfLastPost)
+      : courseInquiries.slice(indexOfFirstPost, indexOfLastPost);
 
   return (
     <>
@@ -621,28 +108,23 @@ export const QnAPagination = () => {
           <div className="user-pagination-tab-menu">
             <button
               className={`user-pagination-tab-button ${
-                activeTab === "QnA" ? "active" : ""
+                activeTab === "메인게시판" ? "active" : ""
               }`}
-              onClick={() => handleTabClick("QnA")}
+              onClick={() => handleTabClick("메인게시판")}
             >
               메인게시판
             </button>
-            <button
-              className={`user-pagination-tab-button ${
-                activeTab === "Sentencing" ? "active" : ""
-              }`}
-              onClick={() => handleTabClick("Sentencing")}
-            >
-              양형교육
-            </button>
-            <button
-              className={`user-pagination-tab-button ${
-                activeTab === "DigitalUndertaker" ? "active" : ""
-              }`}
-              onClick={() => handleTabClick("DigitalUndertaker")}
-            >
-              디지털장의사
-            </button>
+            {categories.map((category) => (
+              <button
+                key={category.id}
+                className={`user-pagination-tab-button ${
+                  activeTab === category.name ? "active" : ""
+                }`}
+                onClick={() => handleTabClick(category.name)}
+              >
+                {category.name}
+              </button>
+            ))}
           </div>
           <Link
             to="/admin/QnA/new"
@@ -653,7 +135,7 @@ export const QnAPagination = () => {
           />
         </div>
         <div className="user-pagination-tab-content">
-          {activeTab === "QnA" && (
+          {activeTab === "메인게시판" && (
             <>
               <div className="user-qna-list margin-top-32">
                 <div className="user-qna-list-header">
@@ -688,7 +170,6 @@ export const QnAPagination = () => {
                       <div>{post.title}</div>
                     </Link>
                     <div>{post.category}</div>
-
                     <div>{post.user_name}</div>
                     <div>{new Date(post.created_at).toLocaleDateString()}</div>
                     <div>{post.view_count}</div>
@@ -714,7 +195,7 @@ export const QnAPagination = () => {
                     />
                   </button>
                   <div className="user-qna-pagination-button-wrap">
-                    {renderPageButtons()}
+                    {renderPageButtons(inquiries.length)}
                   </div>
                   <button
                     className={`user-qna-pagination-button ${
@@ -737,174 +218,97 @@ export const QnAPagination = () => {
               </div>
             </>
           )}
-          {activeTab === "Sentencing" && (
-            <>
-              <div className="user-qna-list margin-top-32">
-                <div className="user-qna-list-header">
-                  <div>No</div>
-                  <div>제목</div>
-                  <div>카테고리</div>
-                  <div>글쓴이</div>
-                  <div>작성일자</div>
-                  <div>조회수</div>
-                </div>
-                {currentPosts2.map((post) => (
-                  <div key={post.id} className="user-qna-item">
-                    <div>{post.id}</div>
-                    <Link
-                      to={`/admin/QnA/${post.id}`}
-                      className="post-item-link"
-                      style={{
-                        backgroundColor: "transparent",
-                        fontFamily: '"Lexend", Helvetica',
-                        fontWeight: "700",
-                        fontSize: "14px",
-                        color: "#dee1e6",
-                        height: "18px",
-                        textAlign: "left",
-                        display: "block",
-                        width: "306px",
-                        textOverflow: "ellipsis",
-                        overflow: "hidden",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      <div>{post.title}</div>
-                    </Link>
-                    <div>{post.category}</div>
-
-                    <div>{post.writer}</div>
-                    <div>{post.publishDate}</div>
-                    <div>{post.views}</div>
+          {categories.map((category) => (
+            <div key={category.id}>
+              {activeTab === category.name && (
+                <>
+                  <div className="user-qna-list margin-top-32">
+                    <div className="user-qna-list-header">
+                      <div>No</div>
+                      <div>제목</div>
+                      <div>카테고리</div>
+                      <div>글쓴이</div>
+                      <div>작성일자</div>
+                      <div>조회수</div>
+                    </div>
+                    {currentPosts.map((inquiry) => (
+                      <div key={inquiry.id} className="user-qna-item">
+                        <div>{inquiry.id}</div>
+                        <Link
+                          to={`/admin/QnA/${inquiry.id}`}
+                          className="post-item-link"
+                          style={{
+                            backgroundColor: "transparent",
+                            fontFamily: '"Lexend", Helvetica',
+                            fontWeight: "700",
+                            fontSize: "14px",
+                            color: "#dee1e6",
+                            height: "18px",
+                            textAlign: "left",
+                            display: "block",
+                            width: "306px",
+                            textOverflow: "ellipsis",
+                            overflow: "hidden",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          <div>{inquiry.title}</div>
+                        </Link>
+                        <div>{inquiry.category}</div>
+                        <div>{inquiry.user_name}</div>
+                        <div>
+                          {new Date(inquiry.created_at).toLocaleDateString()}
+                        </div>
+                        <div>{inquiry.view_count}</div>
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
-              <div className="user-qna-pagination-footer">
-                <div className="user-qna-pagination-count">
-                  {SentencingList.length} results
-                </div>
-                <div className="user-qna-pagination-buttons">
-                  <button
-                    className={`user-qna-pagination-button ${
-                      currentPage2 === 1 ? "disabled" : ""
-                    }`}
-                    onClick={() => handlePageChange2(currentPage2 - 1)}
-                    disabled={currentPage2 === 1}
-                  >
-                    <img
-                      className="img-11"
-                      alt="Chevron left large"
-                      src={leftArrowButton}
-                    />
-                  </button>
-                  <div className="user-qna-pagination-button-wrap">
-                    {renderPageButtons2()}
+                  <div className="user-qna-pagination-footer">
+                    <div className="user-qna-pagination-count">
+                      {courseInquiries.length} results
+                    </div>
+                    <div className="user-qna-pagination-buttons">
+                      <button
+                        className={`user-qna-pagination-button ${
+                          currentPage === 1 ? "disabled" : ""
+                        }`}
+                        onClick={() => handlePageChange(currentPage - 1)}
+                        disabled={currentPage === 1}
+                      >
+                        <img
+                          className="img-11"
+                          alt="Chevron left large"
+                          src={leftArrowButton}
+                        />
+                      </button>
+                      <div className="user-qna-pagination-button-wrap">
+                        {renderPageButtons(courseInquiries.length)}
+                      </div>
+                      <button
+                        className={`user-qna-pagination-button ${
+                          currentPage ===
+                          Math.ceil(courseInquiries.length / postsPerPage)
+                            ? "disabled"
+                            : ""
+                        }`}
+                        onClick={() => handlePageChange(currentPage + 1)}
+                        disabled={
+                          currentPage ===
+                          Math.ceil(courseInquiries.length / postsPerPage)
+                        }
+                      >
+                        <img
+                          className="img-11"
+                          alt="Chevron right large"
+                          src={rightArrowButton}
+                        />
+                      </button>
+                    </div>
                   </div>
-                  <button
-                    className={`user-qna-pagination-button ${
-                      currentPage2 === Math.ceil(totalPosts2 / postsPerPage2)
-                        ? "disabled"
-                        : ""
-                    }`}
-                    onClick={() => handlePageChange2(currentPage2 + 1)}
-                    disabled={
-                      currentPage2 === Math.ceil(totalPosts2 / postsPerPage2)
-                    }
-                  >
-                    <img
-                      className="img-11"
-                      alt="Chevron right large"
-                      src={rightArrowButton}
-                    />
-                  </button>
-                </div>
-              </div>
-            </>
-          )}
-          {activeTab === "DigitalUndertaker" && (
-            <>
-              <div className="user-qna-list margin-top-32">
-                <div className="user-qna-list-header">
-                  <div>No</div>
-                  <div>제목</div>
-                  <div>카테고리</div>
-                  <div>글쓴이</div>
-                  <div>작성일자</div>
-                  <div>조회수</div>
-                </div>
-                {currentPosts3.map((post) => (
-                  <div key={post.id} className="user-qna-item">
-                    <div>{post.id}</div>
-                    <Link
-                      to={`/admin/QnA/${post.id}`}
-                      className="post-item-link"
-                      style={{
-                        backgroundColor: "transparent",
-                        fontFamily: '"Lexend", Helvetica',
-                        fontWeight: "700",
-                        fontSize: "14px",
-                        color: "#dee1e6",
-                        height: "18px",
-                        textAlign: "left",
-                        display: "block",
-                        width: "306px",
-                        textOverflow: "ellipsis",
-                        overflow: "hidden",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      <div>{post.title}</div>
-                    </Link>
-                    <div>{post.category}</div>
-
-                    <div>{post.writer}</div>
-                    <div>{post.publishDate}</div>
-                    <div>{post.views}</div>
-                  </div>
-                ))}
-              </div>
-              <div className="user-qna-pagination-footer">
-                <div className="user-qna-pagination-count">
-                  {DigitalUndertakerList.length} results
-                </div>
-                <div className="user-qna-pagination-buttons">
-                  <button
-                    className={`user-qna-pagination-button ${
-                      currentPage3 === 1 ? "disabled" : ""
-                    }`}
-                    onClick={() => handlePageChange3(currentPage3 - 1)}
-                    disabled={currentPage3 === 1}
-                  >
-                    <img
-                      className="img-11"
-                      alt="Chevron left large"
-                      src={leftArrowButton}
-                    />
-                  </button>
-                  <div className="user-qna-pagination-button-wrap">
-                    {renderPageButtons3()}
-                  </div>
-                  <button
-                    className={`user-qna-pagination-button ${
-                      currentPage3 === Math.ceil(totalPosts3 / postsPerPage3)
-                        ? "disabled"
-                        : ""
-                    }`}
-                    onClick={() => handlePageChange3(currentPage3 + 1)}
-                    disabled={
-                      currentPage3 === Math.ceil(totalPosts3 / postsPerPage3)
-                    }
-                  >
-                    <img
-                      className="img-11"
-                      alt="Chevron right large"
-                      src={rightArrowButton}
-                    />
-                  </button>
-                </div>
-              </div>
-            </>
-          )}
+                </>
+              )}
+            </div>
+          ))}
         </div>
       </div>
     </>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -788,23 +788,25 @@ const useServiceStore = create((set) => ({
     try {
       const response = await getApi({ path: "/courses/categories" });
       if (response) {
+        const categories = response.map((category) => ({
+          id: category.id,
+          name: category.name,
+        }));
         set({
-          categories: response.map((category) => ({
-            id: category.id,
-            name: category.name,
-          })),
+          categories,
           isLoading: false,
         });
         console.log("카테고리를 성공적으로 가져왔습니다.");
+        console.log(response);
+        return categories; // 카테고리 데이터를 반환
       } else {
-        throw new Error(
-          `Failed to fetch categories: Status ${response.status}`
-        );
+        throw new Error(`Failed to fetch categories: Status ${response.status}`);
       }
     } catch (error) {
       set({ error: error.message, isLoading: false });
       console.error("getCategories Error:", error);
-      alert("카테고리를를 가져오는 중 오류가 발생했습니다: " + error.message);
+      alert("카테고리를 가져오는 중 오류가 발생했습니다: " + error.message);
+      return []; // 오류 발생 시 빈 배열 반환
     }
   },
 
@@ -1456,6 +1458,42 @@ const useCourseInquiryStore = create((set) => ({
 
   clearCourseQnA: () => {
     set({ courseQnA: null });
+  },
+
+  getCourseInquiriesByCategory: async (category) => {
+    set({ isLoading: true });
+    try {
+      const response = await getApi({ path: `/category/${category}/qna/` });
+      if (response) {
+        const sortedInquiries = response
+          .map((inquiry) => ({
+            id: inquiry.id,
+            course_id: inquiry.course_id,
+            user_id: inquiry.user_id,
+            title: inquiry.title,
+            content: inquiry.content,
+            created_at: inquiry.created_at,
+            updated_at: inquiry.updated_at,
+            view_count: inquiry.view_count,
+            user_name: inquiry.user_name,
+            comments: inquiry.comments,
+            lecture_id: inquiry.lecture_id,
+            category: inquiry.category,
+          }))
+          .sort((a, b) => b.id - a.id); // 최근순으로 정렬
+
+        set({
+          courseInquiries: sortedInquiries,
+          isLoading: false,
+        });
+        console.log(`${category} 카테고리의 질문 리스트를 성공적으로 가져왔습니다.`);
+      } else {
+        throw new Error(`Failed to fetch inquiries: Status ${response.status}`);
+      }
+    } catch (error) {
+      set({ error: error.message, isLoading: false });
+      alert(`${category} 카테고리의 질문 리스트를 가져오는 중 오류가 발생했습니다: ` + error.message);
+    }
   },
 }));
 


### PR DESCRIPTION
## 변경 사항
- `useCourseInquiryStore`에 선택된 카테고리에 따라 문의를 가져오는 `getCourseInquiriesByCategory` 함수를 추가
- `QnAPagination` 컴포넌트에 API에서 가져온 데이터를 기반으로 카테고리 탭을 동적으로 생성하도록 수정
- 활성화된 탭이 변경될 때 문의를 가져오도록 `useEffect` 훅을 업데이트
- 선택된 카테고리에 따라 문의를 렌더링하도록 수정